### PR TITLE
色とテキストの反映

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:picbook/infrastructure/auth_repository.dart';
 import 'package:picbook/infrastructure/provider/analytics_provider.dart';
 import 'package:picbook/presentation/bottom_navigation/bottom_navigation_page.dart';
 import 'package:picbook/presentation/first_page/first_page.dart';
-
 import 'common/logger_provider.dart';
 
 Future<void> main() async {
@@ -38,7 +37,7 @@ class App extends ConsumerWidget {
           backgroundColor: HexColor('F8F5EE'),
           titleTextStyle: TextStyle(
               color: HexColor('410000'),
-              fontSize: 22,
+              fontSize: 17,
               fontWeight: FontWeight.bold),
           elevation: 0.0,
         ),

--- a/lib/presentation/agreement_page/agreement_page.dart
+++ b/lib/presentation/agreement_page/agreement_page.dart
@@ -12,6 +12,9 @@ class AgreementPage extends StatelessWidget {
     return Scaffold(
         appBar: AppBar(
           title: Text(title),
+          iconTheme: const IconThemeData(
+            color: Colors.brown, //change your color here
+          ),
         ),
         body: WebView(
           initialUrl: url,

--- a/lib/presentation/barcode_scanner_page/barcode_scanner_page.dart
+++ b/lib/presentation/barcode_scanner_page/barcode_scanner_page.dart
@@ -51,7 +51,7 @@ class BarcodeScannerPage extends HookConsumerWidget {
               alignment: Alignment.center,
               color: Colors.white,
               child: const Text(
-                '絵本の裏側にあるバーコード\nをスキャンすると絵本を検索することが可能です。',
+                '絵本についてるバーコードを読み取って検索しよう',
                 style: TextStyle(
                   fontSize: 18,
                 ),

--- a/lib/presentation/book_detail/book_detail_page.dart
+++ b/lib/presentation/book_detail/book_detail_page.dart
@@ -79,7 +79,7 @@ class BookDetailPage extends HookConsumerWidget {
               ElevatedButton(
                   onPressed: () {
                     bookNotifier.registerBook(book: bookState);
-                    showAlertDialog(ref, title: '本の追加', content: '本の追加が完了しました');
+                    showAlertDialog(ref, title: '絵本の追加', content: '絵本を追加しました。');
                   },
                   child: Container(
                     padding: const EdgeInsets.all(15),

--- a/lib/presentation/first_page/first_page.dart
+++ b/lib/presentation/first_page/first_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:picbook/presentation/agreement_page/agreement_page.dart';
 import 'package:picbook/presentation/login/login_page.dart';
-
 import '../signup/signup_page.dart';
 
 class FirstPage extends StatelessWidget {
@@ -11,7 +10,6 @@ class FirstPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white70,
       body: Column(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
@@ -19,79 +17,71 @@ class FirstPage extends StatelessWidget {
           Container(
             height: 200,
             width: 200,
-            decoration: const BoxDecoration(
-              color: Colors.black12,
-            ),
-            child: const Center(
-              child: Text(
-                "ロゴ",
-                style: TextStyle(fontWeight: FontWeight.w700),
-              ),
-            ),
+            decoration: const BoxDecoration(),
+            child: Image.asset('lib/assets/images/splash.png'),
           ),
-          const SizedBox(height: 10),
           const Text(
             "アカウントをお持ちの方",
             style: TextStyle(fontWeight: FontWeight.w600),
           ),
-          TextButton(
-            onPressed: () {
-              Navigator.push(
+          ElevatedButton(
+              onPressed: () async {
+                await Navigator.push(
                   context,
                   MaterialPageRoute(
                     builder: (context) => const LogInPage(),
-                  ));
-            },
-            child: Container(
-              height: 50,
-              width: 270,
-              decoration: BoxDecoration(
-                color: Colors.white70,
-                border: Border.all(color: Colors.red, width: 0.5),
-              ),
-              child: const Center(
-                child: Text(
-                  "ログイン",
-                  style:
-                      TextStyle(color: Colors.red, fontWeight: FontWeight.w900),
+                  ),
+                );
+              },
+              child: Container(
+                height: 50,
+                width: 270,
+                padding: const EdgeInsets.all(10),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: const [
+                    Text("ログイン",
+                        style: TextStyle(
+                          fontWeight: FontWeight.w100,
+                          fontSize: 16,
+                        )),
+                  ],
                 ),
-              ),
-            ),
-          ),
+              )),
           const SizedBox(
-            height: 20,
+            height: 10,
           ),
           const Text(
             "初めてご利用の方",
             style: TextStyle(fontWeight: FontWeight.w600),
           ),
-          TextButton(
-            onPressed: () async {
-              await Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const SignUpPage(),
+          ElevatedButton(
+              onPressed: () async {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const SignUpPage(),
+                  ),
+                );
+              },
+              child: Container(
+                height: 50,
+                width: 270,
+                padding: const EdgeInsets.all(10),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: const [
+                    Text("メールアドレスで登録",
+                        style: TextStyle(
+                          fontWeight: FontWeight.w100,
+                          fontSize: 16,
+                        )),
+                  ],
                 ),
-              );
-            },
-            child: Container(
-              height: 50,
-              width: 270,
-              decoration: BoxDecoration(
-                color: Colors.white70,
-                border: Border.all(color: Colors.red, width: 0.5),
-              ),
-              child: const Center(
-                child: Text(
-                  "メールアドレスで登録",
-                  style:
-                      TextStyle(color: Colors.red, fontWeight: FontWeight.w600),
-                ),
-              ),
-            ),
-          ),
+              )),
+          const SizedBox(height: 10),
           Container(
-            padding: const EdgeInsets.all(20),
+            padding: const EdgeInsets.only(left: 40.0, right: 40.0),
             child: RichText(
               text: TextSpan(
                 style: const TextStyle(
@@ -115,8 +105,8 @@ class FirstPage extends StatelessWidget {
                                           "https://pj-picbook.github.io/picdoc/docs/terms.html",
                                     )));
                       },
-                    style: const TextStyle(
-                      color: Colors.blue,
+                    style: TextStyle(
+                      color: Colors.deepOrange.shade700,
                       fontWeight: FontWeight.w600,
                       decoration: TextDecoration.underline,
                     ),
@@ -136,8 +126,8 @@ class FirstPage extends StatelessWidget {
                                     url:
                                         "https://pj-picbook.github.io/picdoc/docs/privacypolicy.html")));
                       },
-                    style: const TextStyle(
-                        color: Colors.blue,
+                    style: TextStyle(
+                        color: Colors.deepOrange.shade700,
                         fontWeight: FontWeight.w600,
                         decoration: TextDecoration.underline),
                   ),
@@ -147,6 +137,9 @@ class FirstPage extends StatelessWidget {
                 ],
               ),
             ),
+          ),
+          const SizedBox(
+            height: 70,
           ),
         ],
       ),

--- a/lib/presentation/login/login_page.dart
+++ b/lib/presentation/login/login_page.dart
@@ -5,7 +5,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:picbook/common/logger_provider.dart';
 import 'package:picbook/main.dart';
 import 'package:picbook/presentation/login/login_notifier.dart';
-
 import '../agreement_page/agreement_page.dart';
 
 class LogInPage extends HookConsumerWidget {
@@ -21,13 +20,13 @@ class LogInPage extends HookConsumerWidget {
       appBar: AppBar(
         title: const Text(
           "ログイン",
-          style: TextStyle(fontSize: 17.0, color: Colors.white),
         ),
-        backgroundColor: Colors.blue[900],
+        iconTheme: const IconThemeData(
+          color: Colors.brown, //change your color here
+        ),
       ),
       body: Form(
         child: Container(
-          color: Colors.grey[300],
           padding: const EdgeInsets.only(left: 40.0, right: 40.0),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -36,7 +35,7 @@ class LogInPage extends HookConsumerWidget {
                 alignment: Alignment.centerLeft,
                 child: Text(
                   "メールアドレス",
-                  style: TextStyle(fontSize: 17.0, fontWeight: FontWeight.bold),
+                  style: TextStyle(fontSize: 14.0, fontWeight: FontWeight.bold),
                 ),
               ),
               Container(
@@ -44,7 +43,7 @@ class LogInPage extends HookConsumerWidget {
                 width: 300,
                 decoration: BoxDecoration(
                   color: Colors.white70,
-                  border: Border.all(color: Colors.red, width: 0.5),
+                  border: Border.all(color: Colors.brown, width: 0.5),
                 ),
                 child: TextFormField(
                   controller: emailController,
@@ -53,8 +52,6 @@ class LogInPage extends HookConsumerWidget {
                   textAlign: TextAlign.center,
                   decoration: const InputDecoration(
                     border: InputBorder.none,
-                    hintText: "xxxxxx@xxxxxxxxxxx",
-                    hintStyle: TextStyle(fontSize: 13.0),
                   ),
                 ),
               ),
@@ -65,7 +62,7 @@ class LogInPage extends HookConsumerWidget {
                 alignment: Alignment.centerLeft,
                 child: Text(
                   "パスワード",
-                  style: TextStyle(fontSize: 17.0, fontWeight: FontWeight.bold),
+                  style: TextStyle(fontSize: 14.0, fontWeight: FontWeight.bold),
                 ),
               ),
               Container(
@@ -73,7 +70,7 @@ class LogInPage extends HookConsumerWidget {
                 width: 300,
                 decoration: BoxDecoration(
                   color: Colors.white70,
-                  border: Border.all(color: Colors.red, width: 0.5),
+                  border: Border.all(color: Colors.brown, width: 0.5),
                 ),
                 child: TextFormField(
                   controller: passwordController,
@@ -82,22 +79,13 @@ class LogInPage extends HookConsumerWidget {
                   textAlign: TextAlign.center,
                   decoration: const InputDecoration(
                     border: InputBorder.none,
-                    hintText: "………………………",
-                    hintStyle: TextStyle(fontSize: 13.0),
                   ),
                 ),
               ),
               const SizedBox(
-                height: 40.0,
+                height: 60.0,
               ),
-              Container(
-                height: 50,
-                width: 300,
-                decoration: BoxDecoration(
-                  color: Colors.white70,
-                  border: Border.all(color: Colors.red, width: 0.5),
-                ),
-                child: TextButton(
+              ElevatedButton(
                   onPressed: () async {
                     try {
                       await notifier.logIn();
@@ -111,16 +99,21 @@ class LogInPage extends HookConsumerWidget {
                       logger.e(e);
                     }
                   },
-                  child: const Text(
-                    "ログインする",
-                    style: TextStyle(
-                      color: Colors.red,
-                      fontSize: 16.0,
-                      fontWeight: FontWeight.w900,
+                  child: Container(
+                    height: 50,
+                    width: 270,
+                    padding: const EdgeInsets.all(10),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: const [
+                        Text("ログイン",
+                            style: TextStyle(
+                              fontWeight: FontWeight.w100,
+                              fontSize: 16,
+                            )),
+                      ],
                     ),
-                  ),
-                ),
-              ),
+                  )),
               const SizedBox(
                 height: 20.0,
               ),
@@ -142,21 +135,24 @@ class LogInPage extends HookConsumerWidget {
                             context,
                             MaterialPageRoute(
                               builder: (context) => const AgreementPage(
-                                title: "利用規約",
+                                title: "お問い合わせフォーム",
                                 url:
-                                    "https://pj-picbook.github.io/picdoc/docs/terms.html",
+                                    "https://docs.google.com/forms/d/e/1FAIpQLSc1mHvSYh_bMLD6j5lZsBAdbP-jdViXPrJWbX_CSBMPZNbD0A/viewform",
                               ),
                             ),
                           );
                         },
-                      style: const TextStyle(
-                        color: Colors.blue,
+                      style: TextStyle(
+                        color: Colors.deepOrange.shade700,
                         fontWeight: FontWeight.w600,
                         decoration: TextDecoration.underline,
                       ),
                     ),
                   ],
                 ),
+              ),
+              const SizedBox(
+                height: 50.0,
               ),
             ],
           ),

--- a/lib/presentation/mypage/mypage.dart
+++ b/lib/presentation/mypage/mypage.dart
@@ -200,33 +200,33 @@ class MyPage extends HookConsumerWidget {
             const SizedBox(
               height: 25,
             ),
-            TextButton(
-              onPressed: () async {
-                await notifier.logOut();
-                await analytics.sendButtonEvent(buttonName: 'ログアウト');
-                (() => Navigator.pushAndRemoveUntil(
-                    context,
-                    MaterialPageRoute<App>(
-                      builder: (context) => const App(),
-                    ),
-                    (route) => false))();
-              },
-              child: Container(
-                height: 50,
-                width: 270,
-                decoration: BoxDecoration(
-                  color: Colors.brown,
-                  border: Border.all(color: Colors.brown, width: 2),
-                ),
-                child: const Center(
-                  child: Text(
-                    "ログアウトする",
-                    style: TextStyle(
-                        color: Colors.white, fontWeight: FontWeight.w600),
+
+            ElevatedButton(
+                onPressed: () async {
+                  await notifier.logOut();
+                  await analytics.sendButtonEvent(buttonName: 'ログアウト');
+                  (() => Navigator.pushAndRemoveUntil(
+                      context,
+                      MaterialPageRoute<App>(
+                        builder: (context) => const App(),
+                      ),
+                      (route) => false))();
+                },
+                child: Container(
+                  height: 50,
+                  width: 270,
+                  padding: const EdgeInsets.all(10),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: const [
+                      Text('ログアウトする',
+                          style: TextStyle(
+                            fontWeight: FontWeight.w100,
+                            fontSize: 16,
+                          )),
+                    ],
                   ),
-                ),
-              ),
-            ),
+                )),
           ],
         ),
       ),

--- a/lib/presentation/searchbook/searchbook_page.dart
+++ b/lib/presentation/searchbook/searchbook_page.dart
@@ -74,7 +74,7 @@ class SearchBookPage extends HookConsumerWidget {
                         onPressed: () async {
                           bookNotifier.registerBook(book: item);
                           showAlertDialog(ref,
-                              title: '本の追加', content: '本の追加が完了しました');
+                              title: '絵本の追加', content: '絵本を追加しました。');
                         },
                         book: item,
                       ),

--- a/lib/presentation/signup/signup_page.dart
+++ b/lib/presentation/signup/signup_page.dart
@@ -327,7 +327,7 @@ class SignUpPage extends HookConsumerWidget {
                         },
                       style: TextStyle(
                         color: Colors.deepOrange.shade700,
-                        fontWeight: FontWeight.w100,
+                        fontWeight: FontWeight.w600,
                         decoration: TextDecoration.underline,
                       ),
                     ),

--- a/lib/presentation/signup/signup_page.dart
+++ b/lib/presentation/signup/signup_page.dart
@@ -8,8 +8,8 @@ import 'package:picbook/presentation/widget/bottom_picker.dart';
 import '../../main.dart';
 import '../agreement_page/agreement_page.dart';
 import 'package:intl/intl.dart';
-
 import 'signup_notifier.dart';
+import 'package:hexcolor/hexcolor.dart';
 
 class SignUpPage extends HookConsumerWidget {
   const SignUpPage({Key? key}) : super(key: key);
@@ -26,24 +26,53 @@ class SignUpPage extends HookConsumerWidget {
       appBar: AppBar(
         title: const Text(
           "会員登録",
-          style: TextStyle(fontSize: 17.0, color: Colors.white),
+          style: TextStyle(
+            fontSize: 17.0,
+          ),
         ),
-        backgroundColor: Colors.blue[900],
+        iconTheme: const IconThemeData(
+          color: Colors.brown, //change your color here
+        ),
       ),
       body: Form(
         child: Container(
-          color: Colors.grey[300],
           padding: const EdgeInsets.only(left: 40.0, right: 40.0),
           child: ListView(
             children: [
               const SizedBox(
-                height: 20.0,
+                height: 30.0,
+              ),
+              Row(
+                children: [
+                  SizedBox(
+                    width: 50,
+                    child: Icon(
+                      Icons.key,
+                      color: HexColor('410000'),
+                      size: 24.0,
+                      semanticLabel: 'Text to announce in accessibility modes',
+                    ),
+                  ),
+                  Center(
+                    child: Text(
+                      "ログイン情報",
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16.0,
+                        color: HexColor('410000'),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(
+                height: 10.0,
               ),
               const Align(
                 alignment: Alignment.centerLeft,
                 child: Text(
-                  "なまえ",
-                  style: TextStyle(fontSize: 17.0, fontWeight: FontWeight.bold),
+                  "メールアドレス",
+                  style: TextStyle(fontSize: 14.0, fontWeight: FontWeight.bold),
                 ),
               ),
               Container(
@@ -51,26 +80,104 @@ class SignUpPage extends HookConsumerWidget {
                 width: 300,
                 decoration: BoxDecoration(
                   color: Colors.white70,
-                  border: Border.all(color: Colors.red, width: 0.5),
+                  border: Border.all(color: Colors.brown, width: 0.5),
+                ),
+                child: TextFormField(
+                  controller: emailController,
+                  onChanged: ((value) => {notifier.setEmail(value)}),
+                  keyboardType: TextInputType.emailAddress,
+                  textAlign: TextAlign.center,
+                  decoration: const InputDecoration(
+                    border: InputBorder.none,
+                  ),
+                ),
+              ),
+              const SizedBox(
+                height: 10.0,
+              ),
+              const Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  "パスワード",
+                  style: TextStyle(fontSize: 14.0, fontWeight: FontWeight.bold),
+                ),
+              ),
+              Container(
+                height: 50,
+                width: 300,
+                decoration: BoxDecoration(
+                  color: Colors.white70,
+                  border: Border.all(color: Colors.brown, width: 0.5),
+                ),
+                child: TextFormField(
+                  controller: passwordController,
+                  onChanged: ((value) => {notifier.setPassword(value)}),
+                  obscureText: true,
+                  textAlign: TextAlign.center,
+                  decoration: const InputDecoration(
+                    border: InputBorder.none,
+                  ),
+                ),
+              ),
+              const SizedBox(
+                height: 40.0,
+              ),
+              Row(
+                children: [
+                  SizedBox(
+                    width: 50,
+                    child: Icon(
+                      Icons.person_add,
+                      color: HexColor('410000'),
+                      size: 24.0,
+                      semanticLabel: 'Text to announce in accessibility modes',
+                    ),
+                  ),
+                  Center(
+                    child: Text(
+                      "絵本を読む人の情報",
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16.0,
+                        color: HexColor('410000'),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(
+                height: 10.0,
+              ),
+              const Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  "なまえ",
+                  style: TextStyle(fontSize: 14.0, fontWeight: FontWeight.bold),
+                ),
+              ),
+              Container(
+                height: 50,
+                width: 300,
+                decoration: BoxDecoration(
+                  color: Colors.white70,
+                  border: Border.all(color: Colors.brown, width: 0.5),
                 ),
                 child: TextFormField(
                   textAlign: TextAlign.center,
                   onChanged: (value) => notifier.setName(value),
                   decoration: const InputDecoration(
                     border: InputBorder.none,
-                    hintText: "ご自身もしくはお子様の名前をご入力ください",
-                    hintStyle: TextStyle(fontSize: 13.0),
                   ),
                 ),
               ),
               const SizedBox(
-                height: 20.0,
+                height: 10.0,
               ),
               const Align(
                 alignment: Alignment.centerLeft,
                 child: Text(
                   "生年月日",
-                  style: TextStyle(fontSize: 17.0, fontWeight: FontWeight.bold),
+                  style: TextStyle(fontSize: 14.0, fontWeight: FontWeight.bold),
                 ),
               ),
               Container(
@@ -78,7 +185,7 @@ class SignUpPage extends HookConsumerWidget {
                 width: 300,
                 decoration: BoxDecoration(
                   color: Colors.white70,
-                  border: Border.all(color: Colors.red, width: 0.5),
+                  border: Border.all(color: Colors.brown, width: 0.5),
                 ),
                 child: TextFormField(
                   readOnly: true,
@@ -152,78 +259,19 @@ class SignUpPage extends HookConsumerWidget {
                   textAlign: TextAlign.center,
                   decoration: const InputDecoration(
                     border: InputBorder.none,
-                    hintText: "xxxx / xxx / xx",
                     hintStyle: TextStyle(fontSize: 13.0),
                   ),
                 ),
               ),
               const SizedBox(
-                height: 20.0,
-              ),
-              const Align(
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  "メールアドレス",
-                  style: TextStyle(fontSize: 17.0, fontWeight: FontWeight.bold),
-                ),
+                height: 30.0,
               ),
               Container(
                 height: 50,
                 width: 300,
                 decoration: BoxDecoration(
-                  color: Colors.white70,
-                  border: Border.all(color: Colors.red, width: 0.5),
-                ),
-                child: TextFormField(
-                  controller: emailController,
-                  onChanged: ((value) => {notifier.setEmail(value)}),
-                  keyboardType: TextInputType.emailAddress,
-                  textAlign: TextAlign.center,
-                  decoration: const InputDecoration(
-                    border: InputBorder.none,
-                    hintText: "xxxxxx@xxxxxxxxxxx",
-                    hintStyle: TextStyle(fontSize: 13.0),
-                  ),
-                ),
-              ),
-              const SizedBox(
-                height: 20.0,
-              ),
-              const Align(
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  "パスワード",
-                  style: TextStyle(fontSize: 17.0, fontWeight: FontWeight.bold),
-                ),
-              ),
-              Container(
-                height: 50,
-                width: 300,
-                decoration: BoxDecoration(
-                  color: Colors.white70,
-                  border: Border.all(color: Colors.red, width: 0.5),
-                ),
-                child: TextFormField(
-                  controller: passwordController,
-                  onChanged: ((value) => {notifier.setPassword(value)}),
-                  obscureText: true,
-                  textAlign: TextAlign.center,
-                  decoration: const InputDecoration(
-                    border: InputBorder.none,
-                    hintText: "………………………",
-                    hintStyle: TextStyle(fontSize: 13.0),
-                  ),
-                ),
-              ),
-              const SizedBox(
-                height: 40.0,
-              ),
-              Container(
-                height: 50,
-                width: 300,
-                decoration: BoxDecoration(
-                  color: Colors.white70,
-                  border: Border.all(color: Colors.red, width: 0.5),
+                  color: Colors.brown,
+                  border: Border.all(color: Colors.brown, width: 0.5),
                 ),
                 child: TextButton(
                   onPressed: () async {
@@ -242,7 +290,7 @@ class SignUpPage extends HookConsumerWidget {
                   child: const Text(
                     "登録する",
                     style: TextStyle(
-                      color: Colors.red,
+                      color: Colors.white,
                       fontSize: 16.0,
                       fontWeight: FontWeight.w900,
                     ),
@@ -277,9 +325,9 @@ class SignUpPage extends HookConsumerWidget {
                             ),
                           );
                         },
-                      style: const TextStyle(
-                        color: Colors.blue,
-                        fontWeight: FontWeight.w600,
+                      style: TextStyle(
+                        color: Colors.deepOrange.shade700,
+                        fontWeight: FontWeight.w100,
                         decoration: TextDecoration.underline,
                       ),
                     ),

--- a/lib/presentation/widget/book_box.dart
+++ b/lib/presentation/widget/book_box.dart
@@ -37,6 +37,9 @@ class BookBox extends StatelessWidget {
                 ),
               ),
             ),
+            const SizedBox(
+              width: 10,
+            ),
             Expanded(
               flex: 9,
               child: Column(
@@ -57,7 +60,7 @@ class BookBox extends StatelessWidget {
                       book.author ?? '',
                       style: const TextStyle(
                         color: Color.fromARGB(255, 184, 180, 180),
-                        fontSize: 16,
+                        fontSize: 13,
                       ),
                     ),
                   ),
@@ -72,10 +75,13 @@ class BookBox extends StatelessWidget {
                 },
                 child: const Icon(
                   Icons.add_box,
-                  color: Colors.black38,
-                  size: 30,
+                  color: Colors.brown,
+                  size: 25,
                 ),
               ),
+            ),
+            const SizedBox(
+              width: 10,
             ),
           ],
         ),

--- a/lib/presentation/widget/dialog.dart
+++ b/lib/presentation/widget/dialog.dart
@@ -17,7 +17,7 @@ showAlertDialog(
           child: Container(
             width: 311.0,
             decoration: BoxDecoration(
-              border: Border.all(color: Colors.blueAccent, width: 3),
+              border: Border.all(color: Colors.deepOrange.shade700, width: 3),
               borderRadius: BorderRadius.circular(10.0),
             ),
             child: Column(
@@ -48,7 +48,7 @@ showAlertDialog(
                       style: ElevatedButton.styleFrom(
                         shadowColor: Colors.grey,
                         elevation: 5,
-                        primary: Colors.blueAccent,
+                        primary: Colors.deepOrange.shade700,
                         onPrimary: Colors.white,
                         shape: const StadiumBorder(),
                       ),


### PR DESCRIPTION
# 関連のタスクissue<span style="color: red; ">*</span>

#115

# PR作成時のチェックリスト<span style="color: red; ">*</span>
※対象外の場合は実施していなくてもチェックを入れる
<!-- - [ ] featureブランチの場合、CHANGELOG.mdの次回リリース想定バージョンの箇所に変更点を記載したか 
※ 初回リリースまでは不要
-->
- [x] release|hotfixブランチの場合バージョンをインクリメントしCHANGELOG.mdに変更点が記載されているか
- [x] 未解決の課題がある場合はissueを立てたか

# 対応したこと<span style="color: red; ">*</span>

- ログインページのパスワード忘れのリンク先をgoogleフォームに変更
- 作品追加時のダイアログカラーと文言を変更
- バーコードスキャンページの文言を変更
- サインアップページ、新規登録ページ、ログインページのカラーを変更
- 新規登録画面でログイン情報と本棚持ち主情報を分けて表示
- マイページのボタンを変更
- agreement_pageのアイコンカラーを変更
- 検索画面のいろとサイズ調整



### 変更後のキャプチャ
![Simulator Screen Shot - iPhone 11 Pro - 2022-08-28 at 17 36 14](https://user-images.githubusercontent.com/96728192/187065701-eece1f00-ace2-4e87-9721-cce217e68c3e.png)
![Simulator Screen Shot - iPhone 11 Pro - 2022-08-28 at 17 36 21](https://user-images.githubusercontent.com/96728192/187065630-d0301286-e884-4c5a-9f7b-e45e7bbdc136.png)
![Simulator Screen Shot - iPhone 11 Pro - 2022-08-28 at 17 36 17](https://user-images.githubusercontent.com/96728192/187065633-ac286901-beff-4be3-820e-53fcde1681a5.png)
![Simulator Screen Shot - iPhone 11 Pro - 2022-08-28 at 17 16 22](https://user-images.githubusercontent.com/96728192/187065704-4ee2b2e1-f079-4f8e-b535-97884c63d6fb.png)
![Simulator Screen Shot - iPhone 11 Pro - 2022-08-28 at 17 35 52](https://user-images.githubusercontent.com/96728192/187065636-b603bebb-c32b-4e35-891c-87a5d8690407.png)
![Simulator Screen Shot - iPhone 11 Pro - 2022-08-28 at 18 25 50](https://user-images.githubusercontent.com/96728192/187067215-d65ebb30-b9cf-423d-a314-29505135c3ba.png)

