### PR TITLE
検索結果の無限スクロール

### DIFF
--- a/lib/domain/entity/rakuten/items.dart
+++ b/lib/domain/entity/rakuten/items.dart
@@ -21,4 +21,15 @@ class Items with _$Items {
   }) = _Items;
 
   factory Items.fromJson(Map<String, dynamic> json) => _$ItemsFromJson(json);
+
+  factory Items.dummy() => Items(
+        items: [],
+        count: 0,
+        page: 0,
+        first: 0,
+        last: 0,
+        hits: 0,
+        carrier: 0,
+        pageCount: 0,
+      );
 }

--- a/lib/domain/entity/rakuten/items.dart
+++ b/lib/domain/entity/rakuten/items.dart
@@ -22,7 +22,7 @@ class Items with _$Items {
 
   factory Items.fromJson(Map<String, dynamic> json) => _$ItemsFromJson(json);
 
-  factory Items.dummy() => Items(
+  factory Items.initial() => Items(
         items: [],
         count: 0,
         page: 0,

--- a/lib/infrastructure/rakuten_book_repository.dart
+++ b/lib/infrastructure/rakuten_book_repository.dart
@@ -32,11 +32,11 @@ class RakutenBookRepository {
     final client = await httpClient.connect(type: RequestType.get);
 
     if (client.isParameterError || client.response == null) {
-      return SearchBookState(items: Items.dummy(), books: []);
+      return SearchBookState(items: Items.initial(), books: []);
     }
 
     if (client.response!.statusCode != 200) {
-      return SearchBookState(items: Items.dummy(), books: []);
+      return SearchBookState(items: Items.initial(), books: []);
     }
 
     final bookItems = Items.fromJson(convert.jsonDecode(client.response!.body));

--- a/lib/infrastructure/rakuten_book_repository.dart
+++ b/lib/infrastructure/rakuten_book_repository.dart
@@ -21,7 +21,7 @@ class RakutenBookRepository {
   Future<SearchBookState> search({
     required SearchType searchType,
     required String keyWord,
-    List<Book>? addBooks,
+    List<Book> addBooks = const [],
     int getPage = 1,
   }) async {
     final httpClient = HttpClient(
@@ -42,7 +42,7 @@ class RakutenBookRepository {
 
     final bookItems = Items.fromJson(convert.jsonDecode(client.response!.body));
     // TODO:バリデーション
-    final List<Book> books = [];
+    List<Book> books = [];
 
     for (final item in bookItems.items) {
       books.add(
@@ -72,11 +72,9 @@ class RakutenBookRepository {
       );
     }
 
-    if (addBooks != null) {
-      books.addAll(addBooks);
-    }
-
-    return SearchBookState(items: bookItems, books: books);
+    return SearchBookState(
+        items: bookItems,
+        books: addBooks.isNotEmpty ? addBooks + books : books);
   }
 
   Uri _createUri({

--- a/lib/infrastructure/rakuten_book_repository.dart
+++ b/lib/infrastructure/rakuten_book_repository.dart
@@ -1,6 +1,5 @@
 import 'dart:convert' as convert;
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:picbook/domain/entity/rakuten/item.dart';
 
 import '../../state/search_book_state.dart';
 import '../domain/entity/book.dart';

--- a/lib/presentation/searchbook/searchbook_page_notifier.dart
+++ b/lib/presentation/searchbook/searchbook_page_notifier.dart
@@ -15,7 +15,7 @@ class SearchBookPageNotifier extends StateNotifier<SearchBookState> {
   SearchBookPageNotifier({
     required RakutenBookRepository rakutenBookRepository,
   })  : _rakutenBookRepository = rakutenBookRepository,
-        super(SearchBookState(items: Items.dummy(), books: []));
+        super(SearchBookState(items: Items.initial(), books: []));
 
   final RakutenBookRepository _rakutenBookRepository;
 

--- a/lib/presentation/searchbook/searchbook_page_notifier.dart
+++ b/lib/presentation/searchbook/searchbook_page_notifier.dart
@@ -34,6 +34,8 @@ class SearchBookPageNotifier extends StateNotifier<SearchBookState> {
     );
     _nowSearchType = searchType;
     _nowSearchKeyWord = keyWord;
+    _nowGetPage = 1;
+    _isLoading = false;
   }
 
   Future<void> loadIfNeeded(int readIndex) async {

--- a/lib/presentation/searchbook/searchbook_page_notifier.dart
+++ b/lib/presentation/searchbook/searchbook_page_notifier.dart
@@ -1,6 +1,7 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../infrastructure/rakuten_book_repository.dart';
 import '../../state/search_book_state.dart';
+import '../../domain/entity/rakuten/items.dart';
 
 final rakutenBookPageNotifierProvider =
     StateNotifierProvider<SearchBookPageNotifier, SearchBookState>((ref) {
@@ -14,9 +15,14 @@ class SearchBookPageNotifier extends StateNotifier<SearchBookState> {
   SearchBookPageNotifier({
     required RakutenBookRepository rakutenBookRepository,
   })  : _rakutenBookRepository = rakutenBookRepository,
-        super(SearchBookState(books: []));
+        super(SearchBookState(items: Items.dummy(), books: []));
 
   final RakutenBookRepository _rakutenBookRepository;
+
+  int _nowGetPage = 1;
+  bool _isLoading = false;
+  SearchType _nowSearchType = SearchType.keyword;
+  String _nowSearchKeyWord = '';
 
   Future<void> fetch({
     required SearchType searchType,
@@ -26,5 +32,22 @@ class SearchBookPageNotifier extends StateNotifier<SearchBookState> {
       searchType: searchType,
       keyWord: keyWord,
     );
+    _nowSearchType = searchType;
+    _nowSearchKeyWord = keyWord;
+  }
+
+  Future<void> loadIfNeeded(int readIndex) async {
+    if (_nowGetPage == state.items.pageCount) return;
+    if (readIndex < state.items.last || _isLoading) return;
+
+    _isLoading = true;
+    ++_nowGetPage;
+    state = await _rakutenBookRepository.search(
+      searchType: _nowSearchType,
+      keyWord: _nowSearchKeyWord,
+      getPage: _nowGetPage,
+      addBooks: state.books,
+    );
+    _isLoading = false;
   }
 }

--- a/lib/presentation/searchbook/searchbook_page_result.dart
+++ b/lib/presentation/searchbook/searchbook_page_result.dart
@@ -12,7 +12,9 @@ class SearchBookResultPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(rakutenBookPageNotifierProvider);
+    final rakutenBookstate = ref.watch(rakutenBookPageNotifierProvider);
+    final rakutenBookNotifier =
+        ref.watch(rakutenBookPageNotifierProvider.notifier);
     final bookNotifier = ref.watch(bookNotifierProvider.notifier);
     final bookshelfNotifier = ref.read(bookshelfNotifierProvider.notifier);
     final bookshelfState = ref.watch(bookshelfNotifierProvider);
@@ -35,9 +37,11 @@ class SearchBookResultPage extends HookConsumerWidget {
             ),
             Flexible(
               child: ListView.builder(
-                itemCount: state.books.length,
+                itemCount: rakutenBookstate.books.length,
                 itemBuilder: (context, index) {
-                  final item = state.books[index];
+                  final item = rakutenBookstate.books[index];
+                  rakutenBookNotifier.loadIfNeeded(index + 1);
+
                   return InkWell(
                       child: BookBox(
                         onPressed: () async {

--- a/lib/state/search_book_state.dart
+++ b/lib/state/search_book_state.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:flutter/foundation.dart';
 import '../../domain/entity/book.dart';
+import '../domain/entity/rakuten/items.dart';
 
 part 'search_book_state.freezed.dart';
 
@@ -9,6 +10,7 @@ class SearchBookState with _$SearchBookState {
   const SearchBookState._();
 
   factory SearchBookState({
+    required Items items,
     required List<Book> books,
   }) = _SearchBookState;
 }

--- a/lib/state/search_book_state.freezed.dart
+++ b/lib/state/search_book_state.freezed.dart
@@ -16,6 +16,7 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$SearchBookState {
+  Items get items => throw _privateConstructorUsedError;
   List<Book> get books => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
@@ -28,7 +29,9 @@ abstract class $SearchBookStateCopyWith<$Res> {
   factory $SearchBookStateCopyWith(
           SearchBookState value, $Res Function(SearchBookState) then) =
       _$SearchBookStateCopyWithImpl<$Res>;
-  $Res call({List<Book> books});
+  $Res call({Items items, List<Book> books});
+
+  $ItemsCopyWith<$Res> get items;
 }
 
 /// @nodoc
@@ -42,14 +45,26 @@ class _$SearchBookStateCopyWithImpl<$Res>
 
   @override
   $Res call({
+    Object? items = freezed,
     Object? books = freezed,
   }) {
     return _then(_value.copyWith(
+      items: items == freezed
+          ? _value.items
+          : items // ignore: cast_nullable_to_non_nullable
+              as Items,
       books: books == freezed
           ? _value.books
           : books // ignore: cast_nullable_to_non_nullable
               as List<Book>,
     ));
+  }
+
+  @override
+  $ItemsCopyWith<$Res> get items {
+    return $ItemsCopyWith<$Res>(_value.items, (value) {
+      return _then(_value.copyWith(items: value));
+    });
   }
 }
 
@@ -60,7 +75,10 @@ abstract class _$$_SearchBookStateCopyWith<$Res>
           _$_SearchBookState value, $Res Function(_$_SearchBookState) then) =
       __$$_SearchBookStateCopyWithImpl<$Res>;
   @override
-  $Res call({List<Book> books});
+  $Res call({Items items, List<Book> books});
+
+  @override
+  $ItemsCopyWith<$Res> get items;
 }
 
 /// @nodoc
@@ -76,9 +94,14 @@ class __$$_SearchBookStateCopyWithImpl<$Res>
 
   @override
   $Res call({
+    Object? items = freezed,
     Object? books = freezed,
   }) {
     return _then(_$_SearchBookState(
+      items: items == freezed
+          ? _value.items
+          : items // ignore: cast_nullable_to_non_nullable
+              as Items,
       books: books == freezed
           ? _value._books
           : books // ignore: cast_nullable_to_non_nullable
@@ -90,10 +113,12 @@ class __$$_SearchBookStateCopyWithImpl<$Res>
 /// @nodoc
 
 class _$_SearchBookState extends _SearchBookState with DiagnosticableTreeMixin {
-  _$_SearchBookState({required final List<Book> books})
+  _$_SearchBookState({required this.items, required final List<Book> books})
       : _books = books,
         super._();
 
+  @override
+  final Items items;
   final List<Book> _books;
   @override
   List<Book> get books {
@@ -103,7 +128,7 @@ class _$_SearchBookState extends _SearchBookState with DiagnosticableTreeMixin {
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'SearchBookState(books: $books)';
+    return 'SearchBookState(items: $items, books: $books)';
   }
 
   @override
@@ -111,6 +136,7 @@ class _$_SearchBookState extends _SearchBookState with DiagnosticableTreeMixin {
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('type', 'SearchBookState'))
+      ..add(DiagnosticsProperty('items', items))
       ..add(DiagnosticsProperty('books', books));
   }
 
@@ -119,12 +145,15 @@ class _$_SearchBookState extends _SearchBookState with DiagnosticableTreeMixin {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_SearchBookState &&
+            const DeepCollectionEquality().equals(other.items, items) &&
             const DeepCollectionEquality().equals(other._books, _books));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(_books));
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(items),
+      const DeepCollectionEquality().hash(_books));
 
   @JsonKey(ignore: true)
   @override
@@ -133,10 +162,13 @@ class _$_SearchBookState extends _SearchBookState with DiagnosticableTreeMixin {
 }
 
 abstract class _SearchBookState extends SearchBookState {
-  factory _SearchBookState({required final List<Book> books}) =
-      _$_SearchBookState;
+  factory _SearchBookState(
+      {required final Items items,
+      required final List<Book> books}) = _$_SearchBookState;
   _SearchBookState._() : super._();
 
+  @override
+  Items get items;
   @override
   List<Book> get books;
   @override

--- a/test/mock/container.mocks.dart
+++ b/test/mock/container.mocks.dart
@@ -566,6 +566,8 @@ class MockRakutenBookRepository extends _i1.Mock
   _i8.Future<_i5.SearchBookState> search({
     required _i14.SearchType? searchType,
     required String? keyWord,
+    List<_i13.Book>? addBooks = const [],
+    int? getPage = 1,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -574,6 +576,8 @@ class MockRakutenBookRepository extends _i1.Mock
           {
             #searchType: searchType,
             #keyWord: keyWord,
+            #addBooks: addBooks,
+            #getPage: getPage,
           },
         ),
         returnValue:
@@ -585,6 +589,8 @@ class MockRakutenBookRepository extends _i1.Mock
             {
               #searchType: searchType,
               #keyWord: keyWord,
+              #addBooks: addBooks,
+              #getPage: getPage,
             },
           ),
         )),


### PR DESCRIPTION
# 関連のタスクissue<span style="color: red; ">*</span>

- [#195 ]

# PR作成時のチェックリスト<span style="color: red; ">*</span>
※対象外の場合は実施していなくてもチェックを入れる
<!-- - [ ] featureブランチの場合、CHANGELOG.mdの次回リリース想定バージョンの箇所に変更点を記載したか 
※ 初回リリースまでは不要
-->
- [ ] release|hotfixブランチの場合バージョンをインクリメントしCHANGELOG.mdに変更点が記載されているか
- [ ] 未解決の課題がある場合はissueを立てたか

# 対応したこと<span style="color: red; ">*</span>
検索結果を今まで１ページしか出してなかったが、下にスクロールすれば返却されているページ数分ちゃんと表示する様に修正。


# その他・備考
重いのでパフォーマンスを考える必要がある。読み出す時のエフェクト止めた方がええかも？